### PR TITLE
Add support for multiple tags selection

### DIFF
--- a/Desktop/Classes/LoggerWindowController.h
+++ b/Desktop/Classes/LoggerWindowController.h
@@ -70,7 +70,7 @@
 	NSPredicate *filterPredicate;				// created from current selected filters, + quick filter string / tag / log level
 
 	NSString *filterString;
-	NSString *filterTag;
+	NSMutableSet *filterTags;
 	int logLevel;
 
 	dispatch_queue_t messageFilteringQueue;


### PR DESCRIPTION
Using the Option key, multiple tags can now be selected to filter the
current view.
Selecting a single tag also reset to All Tags now.